### PR TITLE
Dep Upgrade: fix tests and linter errors

### DIFF
--- a/src/babashka/neil.clj
+++ b/src/babashka/neil.clj
@@ -419,7 +419,7 @@ will return libraries with 'test framework' in their description.")))
                  :version (:version search-result)
                  :description (pr-str (:description search-result)))))))
 
-(defn dep-upgrade [{:keys [opts] :as all}]
+(defn dep-upgrade [{:keys [opts] :as _all}]
   (if (:lib opts)
     ;; upgrade a single dependency
     (let [lib (:lib opts)

--- a/test/babashka/neil/test_util.clj
+++ b/test/babashka/neil/test_util.clj
@@ -22,12 +22,13 @@
 (defn set-deps-edn! [x]
   (spit (test-file "deps.edn") (pr-str x)))
 
-(defn neil [cli-args & {:keys [out] :or {out :string}}]
-  (let [deps-file (str (test-file "deps.edn"))
-        cli-args' (concat (if (string? cli-args)
-                            (process/tokenize cli-args)
-                            cli-args)
-                          [:deps-file deps-file])]
+(defn neil [cli-args & {:keys [deps-file dry-run out] :or {out :string}}]
+  (let [backup-deps-file (str (test-file "deps.edn"))
+        cli-args'        (concat (if (string? cli-args)
+                                   (process/tokenize cli-args)
+                                   cli-args)
+                                 [:deps-file (or deps-file backup-deps-file)]
+                                 (when dry-run [:dry-run "true"]))]
     (binding [*command-line-args* cli-args']
       (let [s (with-out-str (tasks/exec `neil-main/-main))]
         {:out (if (#{:edn} out) (edn/read-string s) (str/trim s))}))))


### PR DESCRIPTION
- [X] This is a minor fix to an open PR: https://github.com/babashka/neil/pull/110

I've been curious about neil and looking for more open source clojure contributions for a while - I saw [this clojurians share](https://clojurians.slack.com/archives/C03KCV7TM6F/p1665578875524599), I thought I'd take a shot at it.

The problem is that the `:dry-run` flag was being ignored when used like this: 

```
(test-util/neil "dep upgrade" :deps-file test-file-path :dry-run true)
```

([call site in the code](https://github.com/babashka/neil/pull/110/files#diff-971ad24024ab537d1b6a3c2d0c37956be2ea8cdf52057b474f150b24d7c3b968R24))

In fact, `:deps-file` is ignored here too.

`test-util/neil` expects all the neil args in a string as the first argument - the rest are ignored (except for `:out`).

This PR:
- updates `test-util/neil` to handle `:deps-file` and `:dry-run` explicitly
- fixes a small linter error in babashka/neil.clj

It might be preferred to instead rewrite the call sites such that :dry-run is included in the first string arg:

```
(test-util/neil "dep upgrade :dry-run true" :deps-file test-file-path)
```

Supporting a passed `:deps-file` may one day be useful for allowing tests to run in parallel.

Feel free to merge or take whatever inspiration from this! Thanks for all the maintenance effort on these great tools!